### PR TITLE
feat: Implement AddSevenStorage contract inheriting from SimpleStorage

### DIFF
--- a/contracts/AddSevenStorage.sol
+++ b/contracts/AddSevenStorage.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { SimpleStorage } from "./SimpleStorage.sol";
+
+
+// inheritance with 'is' after importing de contract
+contract AddSevenStorage is SimpleStorage {
+    // +7
+    // overrides
+    // overide virtual
+    function store (uint256 _newNum) public override  {
+        myFavNum = _newNum + 7;
+    }
+}

--- a/contracts/SimpleStorage.sol
+++ b/contracts/SimpleStorage.sol
@@ -28,8 +28,8 @@ pragma solidity >=0.8.19 <0.9.0; // use versions between 0.8.19 and 0.9.0 (exclu
     // Malik -> 89, the string is the key of each numb and the default value is 0
     mapping(string => uint256) public nameToFavNum;
 
-    function store(uint256 _favNum) public {
-        myFavNum = _favNum;
+    function store(uint256 _favNum) public virtual {
+        myFavNum = _favNum; // +7
     }
 
     // 2 types of view : view (for reading or state view) or pure (for calculations without reading or modifying state)


### PR DESCRIPTION
This commit introduces the `AddSevenStorage` contract, which inherits from the `SimpleStorage` contract. The `AddSevenStorage` contract overrides the `store` function to add 7 to the input number before storing it in the `myFavNum` state variable.

Key changes:
- Created `AddSevenStorage.sol` contract.
- Inherited from `SimpleStorage.sol`.
- Overrode the `store` function to implement the "+7" logic.